### PR TITLE
refactor: moved to bulider type, encapsulated code and making vertical spacing

### DIFF
--- a/tbot/src/main/java/jarkz/tbot/TBotApplication.java
+++ b/tbot/src/main/java/jarkz/tbot/TBotApplication.java
@@ -22,9 +22,10 @@ public class TBotApplication {
     classInfos.stream().forEach(ci -> ci.registerIntoPool());
 
     var executor = new EventExecutor(botApi);
-    try {
 
+    try {
       executor.runPolling();
+
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }

--- a/tbot/src/main/java/jarkz/tbot/core/EventExecutor.java
+++ b/tbot/src/main/java/jarkz/tbot/core/EventExecutor.java
@@ -25,8 +25,7 @@ public class EventExecutor {
 
   public void runPolling() throws InterruptedException {
     while (true) {
-      var params = new GetUpdatesParameters();
-      params.offset = offset;
+      var params = new GetUpdatesParameters.Builder().setOffset(offset).build();
       var updates = api.getUpdates(params);
 
       for (var event : updates) {

--- a/tbot/src/main/java/jarkz/tbot/core/HandlerTask.java
+++ b/tbot/src/main/java/jarkz/tbot/core/HandlerTask.java
@@ -23,6 +23,22 @@ public class HandlerTask implements Runnable {
     return Optional.empty();
   }
 
+  private Object[] buildArgs(Method method) {
+    var parameters = method.getParameters();
+    var args = new Object[parameters.length];
+
+    for (var i = 0; i < parameters.length; i++) {
+      var argType = parameters[i].getType();
+      if (argType == Update.class) {
+        args[i] = event;
+        continue;
+      }
+      args[i] = BotCore.objectPool.get(argType);
+    }
+
+    return args;
+  }
+
   @Override
   public void run() {
 
@@ -32,16 +48,7 @@ public class HandlerTask implements Runnable {
     }
 
     var method = maybeMethod.get();
-    var parameters = method.getParameters();
-    var args = new Object[parameters.length];
-    for (var i = 0; i < parameters.length; i++) {
-      var argType = parameters[i].getType();
-      if (argType == Update.class) {
-        args[i] = event;
-        continue;
-      }
-      args[i] = BotCore.objectPool.get(argType);
-    }
+    var args = buildArgs(method);
 
     var declClass = method.getDeclaringClass();
     var instance = BotCore.objectPool.get(declClass);

--- a/tbot/src/main/java/jarkz/tbot/scanners/PackageScanner.java
+++ b/tbot/src/main/java/jarkz/tbot/scanners/PackageScanner.java
@@ -22,7 +22,6 @@ public class PackageScanner {
   }
 
   public Optional<ClassInfo> scanClass(Class<?> classToScan) {
-
     ClassInfo info = null;
 
     var methods = classToScan.getDeclaredMethods();


### PR DESCRIPTION
# In short

- moved to builder type of `GetUpdateParameters` in `EventHandler`;
- encapsulated code in `HandlerTask`;
- reformat vertical spacing for more readable code.
